### PR TITLE
Make cache's `path` type agnostic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,15 @@
 name = "SerializationCaches"
 uuid = "3f9d9eeb-f6fe-486e-aab5-ad2c1ff40024"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [compat]
-julia = "1.3"
 OrderedCollections = "1.3"
+julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,4 +8,5 @@ CurrentModule = SerializationCaches
 SerializationCache
 fetch!
 put!
+set_up_cache_path
 ```

--- a/src/SerializationCaches.jl
+++ b/src/SerializationCaches.jl
@@ -27,7 +27,10 @@ process is determined by `file_gc_ratio`.
 Note that all `.jls` files in `path` at the time of `SerializationCache`
 construction are considered to be part of constructed cache.
 
-See also: [`fetch!`](@ref), [`put!`](@ref)
+A valid method for function [`set_up_cache_path(path)`](@ref) must exist for the
+given `path`; only `set_up_cache_path(::AbstractString)` currently exists.
+
+See also: [`fetch!`](@ref), [`put!`](@ref), [`set_up_cache_path`](@ref)
 """
 struct SerializationCache{T}
     path::Any

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,5 +37,7 @@ using Test, SerializationCaches, OrderedCollections
         end
         @test all(keys(cache.in_memory) .== ["29", "30", "31", "32", "33"])
         @test cache.file_keys == OrderedSet(["19", "20", "21", "22", "23", "24", "25", "26", "27", "28"])
+
+        @test isdir(set_up_cache_path(joinpath(tmp, "big/made/up/path")))
     end
 end


### PR DESCRIPTION
Needed in service of allowing `SerialiaztionCache` to be extended for use with a path on S3 (`AWSS3.jl`'s `::S3Path`). Open to other approaches/naming bikeshedding!